### PR TITLE
[chore] introduce tag-based auto release build 

### DIFF
--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -1,0 +1,91 @@
+name: Android Build and Release on Tag
+
+on:
+  create:
+
+jobs:
+  build-and-release:
+    if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.KEYSTORE }}
+
+      - uses: actions/checkout@v4
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Gradle build
+        run: ./gradlew clean bundleRelease assembleRelease --no-daemon
+        env:
+          BITRISE: 'true'
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+          BITRISEIO_ANDROID_KEYSTORE_ALIAS: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_ALIAS }}
+          BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+          BITRISEIO_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.BITRISEIO_ANDROID_KEYSTORE_PASSWORD }}
+
+      - name: Extract Version Number
+        run: echo "version=${GITHUB_REF#refs/tags/release/}" >> $GITHUB_ENV
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-build-artifacts
+          path: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ env.version }}
+          draft: false
+          prerelease: false
+          body: "Description of the release for version ${{ env.version }}"
+          commitish: ${{ github.sha }}
+
+      - name: Find APK file
+        run: |
+          apk_path=$(find ./app/build/outputs/apk/release -name "dazn-*.apk" | head -n 1)
+          echo "apk_path=$apk_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset APK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.apk_path }}
+          asset_name: dazn-${{ env.version }}.apk
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Find AAB file
+        run: |
+          aab_path=$(find ./app/build/outputs/bundle/release -name "dazn-*.aab" | head -n 1)
+          echo "aab_path=$aab_path" >> $GITHUB_ENV
+
+      - name: Upload Release Asset AAB
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASES }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.aab_path }}
+          asset_name: dazn-${{ env.version }}.aab
+          asset_content_type: application/vnd.android.package-archive

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.21" />
+    <option name="version" value="1.9.23" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Under the commit history, you will see how I have built everything from scratch 
 refactoring and bug fixes. The interview process was concluded in October, 2021, but I am still keep
 on improving the codes for demonstration purpose.
 
-I still have a plan to further rewrite this App using Jetpack Compose. However, since it is not likely that I will work for DAZN in the future, this may not happen so soon as I give priority to other projects.
+I still have a plan to further rewrite this App using Jetpack Compose. However, since it is not
+likely that I will work for DAZN in the future, this may not happen so soon as I give priority to
+other projects.
 
 Please note that the APIs are supplied by DAZN for recruitment purpose. They may not work at any
 time, as we have already concluded the interview process.
@@ -64,23 +66,38 @@ would be:
 * [Ktlint Gradle](https://github.com/jlleitschuh/ktlint-gradle) - ktlint plugin to check and apply
   code autoformat
 
+## Binaries download
+
+If you want to try out the app without building it, check out
+the [Releases section](https://github.com/ryanw-mobile/dazn-code-challenge/releases) where you can
+find the APK and App Bundles for each major version. A working Giphy API key was applied when
+building the app, therefore you can test it by just installing it.
+
 ## Requirements
 
-* Android Studio Iguana | 2023.2.1 Canary 18
+* Android Studio Iguana | 2023.2.1
 * Android device or simulator running Android 9.0+ (API 28)
 
-## Setting up the keystore
+## Unit tests
 
-* You don't need to setup a keystore to run the debug build. The following instructions are required only if you want to produce the release build.
+* Tests can be executed on Android Studio, by choosing the tests to run
+* Command line options are: ` ./gradlew testDebugUnitTest` and `./gradlew testReleaseUnitTest`
 
-* Android keystore is not being stored in this repository. You need your own keystore to generate
+## Building the App
+
+### Setting up the keystore
+
+Release builds will be signed if either the keystore file or environment variables are set.
+Otherwise, the app will be built unsigned.
+
+### Local
+
+* Android Keystore is not being stored in this repository. You need your own Keystore to generate
   the apk / App Bundle
 
-* To ensure sensitive data are not being pushed to Git by accident, the keystore and its passwords
-  are kept one level up of the project folder, so they are not managed by Git.
-
-* If your project folder is at `/app/dazn-code-challenge/`, the keystore file
-  and `keystore.properties` should be placed at `/app/`
+* If your project folder is at `/app/dazn-code-challenge/`, the Keystore file
+  and `keystore.properties`
+  should be placed at `/app/`
 
 * The format of `keystore.properties` is:
   ```
@@ -90,12 +107,18 @@ would be:
      storePass=<keystore password>
   ```
 
-## Unit tests
+### CI environment
 
-* Tests can be executed on Android Studio, by choosing the tests to run
-* Command line options are: ` ./gradlew testDebugUnitTest` and `./gradlew testReleaseUnitTest`
+* This project has been configured to build automatically on CI.
 
-## Building the App
+* The following environment variables have been set to provide the keystore:
+  ```
+     BITRISE = true
+     HOME = <the home directory of the bitrise environment>
+     BITRISEIO_ANDROID_KEYSTORE_PASSWORD = <your keystore password>
+     BITRISEIO_ANDROID_KEYSTORE_ALIAS = <your keystore alias>
+     BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD = <your keystore private key password>
+  ```
 
 ### Build and install on the connected device
 
@@ -108,20 +131,12 @@ would be:
 * Options are: `Debug`, `Release`
 * Debug builds will have an App package name suffix `.debug`
 
-### Build and sign a bundle for distribution
-
-After August 2021, all new apps and games will be required to publish with the Android App Bundle
-format.
+### Build an apk or bundle for distribution
 
    ```
    ./gradlew clean bundleRelease
-   ```
-
-### Build and sign an apk for distribution
-
-   ```
+   // or
    ./gradlew clean assembleRelease
    ```
 
-* The generated apk(s) will be stored under `app/build/outputs/apk/`
-* Other usages can be listed using `./gradelew tasks`
+* The generated apks and bundles will be stored under `app/build/outputs/apk/`

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,18 +19,22 @@ android {
             def isRunningOnCI = System.getenv("BITRISE") == "true"
             def keystorePropertiesFile = file('../../keystore.properties')
 
-            if (isRunningOnCI || !keystorePropertiesFile.exists()) {
+            if (isRunningOnCI) {
+                println("Signing Config: using environment variables")
                 storeFile = file(System.getenv("KEYSTORE_LOCATION"))
                 storePassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PASSWORD")
                 keyAlias = System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")
                 keyPassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
-            } else {
+            } else if (keystorePropertiesFile.exists()) {
+                println("Signing Config: using keystore properties")
                 Properties keyProps = new Properties()
                 keyProps.load(new FileInputStream(keystorePropertiesFile))
                 storeFile = file(keyProps["store"])
                 keyAlias = keyProps["alias"]
                 storePassword = keyProps["storePass"]
                 keyPassword = keyProps["pass"]
+            } else {
+                println("Signing Config: skipping signing")
             }
         }
     }
@@ -40,7 +44,7 @@ android {
         minSdk 28
         targetSdk 34
         versionCode 4
-        versionName "1.1.2"
+        versionName "1.1.3"
         resourceConfigurations += ['en']
 
         vectorDrawables.useSupportLibrary = true
@@ -60,7 +64,7 @@ android {
                 variant.outputs.all { output ->
                     def date = new Date()
                     def formattedDate = date.format('yyyyMMdd-HHmmss')
-                    outputFileName = "dazn-${variant.name}-${variant.versionName}-${formattedDate}.apk"
+                    outputFileName = "dazn-${variant.versionName}-${formattedDate}-${variant.name}.apk"
                 }
             }
         }
@@ -70,12 +74,15 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            signingConfig signingConfigs.release
+            if (signingConfigs.getByName("release").keyAlias != null) {
+                signingConfig signingConfigs.release
+            }
+
             applicationVariants.all { variant ->
                 variant.outputs.all { output ->
                     def date = new Date()
                     def formattedDate = date.format('yyyyMMdd-HHmmss')
-                    outputFileName = "dazn-${variant.name}-${variant.versionName}-${formattedDate}.apk"
+                    outputFileName = "dazn-${variant.versionName}-${formattedDate}-${variant.name}.apk"
                 }
             }
         }


### PR DESCRIPTION
Introduce the global ability to generate and submit app builds automatically triggered by tags.
Also updated build.gradle to allow successful release build when there is no keystore and env variables.