### PR TITLE
(#23) fix splash screen

### DIFF
--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -20,11 +20,11 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: set up JDK 21
+      - name: set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '21'
+          java-version: '17'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.DAZNCodeChallenge"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
@@ -21,10 +21,10 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         installSplashScreen()
 
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             DAZNCodeChallengeApp(
                 windowSizeClass = calculateWindowSizeClass(this),

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,7 +15,8 @@
 
     <style name="Theme.DAZNCodeChallenge.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/black</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_dazn</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_dazn_foreground</item>
         <item name="postSplashScreenTheme">@style/Theme.DAZNCodeChallenge</item>
     </style>
 


### PR DESCRIPTION
We have by mistakes assigned a theme to MainActivity, which made the splash screen to fail on older Android versions.
Together we assigned a smaller icon for the splash screen.
The yaml for renovate Github Action was updated to use JDK 17. Probably we won't have any need to elevate it given we are 100% kotlin.