### PR TITLE
(#22) shift initial loading to uievent

### DIFF
--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreen.kt
@@ -87,7 +87,7 @@ fun EventsScreen(
         }
 
         DisposableEffect(true) {
-            uiEvent.onRefresh()
+            uiEvent.onInitialLoad()
             firstRefreshRequested = true
             onDispose { }
         }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsUIEvent.kt
@@ -8,6 +8,7 @@
 package com.rwmobi.dazncodechallenge.ui.destinations.events
 
 data class EventsUIEvent(
+    val onInitialLoad: () -> Unit,
     val onRefresh: () -> Unit,
     val onScrolledToTop: () -> Unit,
     val onErrorShown: (errorId: Long) -> Unit,

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreen.kt
@@ -87,7 +87,7 @@ fun ScheduleScreen(
         }
 
         LaunchedEffect(true) {
-            uiEvent.onRefresh()
+            uiEvent.onInitialLoad()
             firstRefreshRequested = true
 
             while (isActive) {

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleUIEvent.kt
@@ -8,6 +8,7 @@
 package com.rwmobi.dazncodechallenge.ui.destinations.schedule
 
 data class ScheduleUIEvent(
+    val onInitialLoad: () -> Unit,
     val onRefresh: () -> Unit,
     val onScrolledToTop: () -> Unit,
     val onErrorShown: (errorId: Long) -> Unit,

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
@@ -60,7 +60,7 @@ fun AppNavHost(
                 imageLoader = viewModel.getImageLoader(),
                 uiState = uiState,
                 uiEvent = EventsUIEvent(
-                    onInitialLoad = { viewModel.fetchCacheAndReload() },
+                    onInitialLoad = { viewModel.fetchCacheAndRefresh() },
                     onRefresh = { viewModel.refresh() },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Events) },
@@ -89,7 +89,7 @@ fun AppNavHost(
                 imageLoader = viewModel.getImageLoader(),
                 uiState = uiState,
                 uiEvent = ScheduleUIEvent(
-                    onInitialLoad = { viewModel.fetchCacheAndReload() },
+                    onInitialLoad = { viewModel.fetchCacheAndRefresh() },
                     onRefresh = { viewModel.refresh() },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Events) },

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
@@ -60,6 +60,7 @@ fun AppNavHost(
                 imageLoader = viewModel.getImageLoader(),
                 uiState = uiState,
                 uiEvent = EventsUIEvent(
+                    onInitialLoad = { viewModel.fetchCacheAndReload() },
                     onRefresh = { viewModel.refresh() },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Events) },
@@ -88,6 +89,7 @@ fun AppNavHost(
                 imageLoader = viewModel.getImageLoader(),
                 uiState = uiState,
                 uiEvent = ScheduleUIEvent(
+                    onInitialLoad = { viewModel.fetchCacheAndReload() },
                     onRefresh = { viewModel.refresh() },
                     onErrorShown = { viewModel.errorShown(it) },
                     onScrolledToTop = { onScrolledToTop(AppNavItem.Events) },

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
@@ -35,12 +35,6 @@ constructor(
     private val _uiState: MutableStateFlow<EventsUIState> = MutableStateFlow(EventsUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()
 
-    init {
-        viewModelScope.launch(dispatcher) {
-            getEvents()
-        }
-    }
-
     fun errorShown(errorId: Long) {
         _uiState.update { currentUiState ->
             val errorMessages = currentUiState.errorMessages.filterNot { it.id == errorId }
@@ -57,6 +51,14 @@ constructor(
     }
 
     fun getImageLoader() = imageLoader
+
+    fun fetchCacheAndReload() {
+        startLoading()
+        viewModelScope.launch(dispatcher) {
+            getEvents()
+            refresh()
+        }
+    }
 
     fun refresh() {
         startLoading()

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
@@ -52,11 +52,13 @@ constructor(
 
     fun getImageLoader() = imageLoader
 
-    fun fetchCacheAndReload() {
+    fun fetchCacheAndRefresh() {
         startLoading()
         viewModelScope.launch(dispatcher) {
-            getEvents()
-            refresh()
+            val isSuccess = getEvents()
+            if (isSuccess) {
+                refresh()
+            }
         }
     }
 
@@ -76,18 +78,22 @@ constructor(
         }
     }
 
-    private suspend fun getEvents() {
+    private suspend fun getEvents(): Boolean {
         val getEventsResult = repository.getEvents()
-        when (getEventsResult.isFailure) {
-            true -> {
+        return when (getEventsResult.isSuccess) {
+            false -> {
                 updateUIForError("Error getting data: ${getEventsResult.exceptionOrNull()?.message}")
+                false
             }
 
-            false -> _uiState.update { currentUiState ->
-                currentUiState.copy(
-                    isLoading = false,
-                    events = getEventsResult.getOrNull() ?: emptyList(),
-                )
+            true -> {
+                _uiState.update { currentUiState ->
+                    currentUiState.copy(
+                        isLoading = false,
+                        events = getEventsResult.getOrNull() ?: emptyList(),
+                    )
+                }
+                true
             }
         }
     }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
@@ -33,12 +33,6 @@ class ScheduleViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<ScheduleUIState> = MutableStateFlow(ScheduleUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()
 
-    init {
-        viewModelScope.launch(dispatcher) {
-            getSchedule()
-        }
-    }
-
     fun errorShown(errorId: Long) {
         _uiState.update { currentUiState ->
             val errorMessages = currentUiState.errorMessages.filterNot { it.id == errorId }
@@ -55,6 +49,14 @@ class ScheduleViewModel @Inject constructor(
     }
 
     fun getImageLoader() = imageLoader
+
+    fun fetchCacheAndReload() {
+        startLoading()
+        viewModelScope.launch(dispatcher) {
+            getSchedule()
+            refresh()
+        }
+    }
 
     fun refresh() {
         startLoading()

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModelTest.kt
@@ -32,9 +32,6 @@ internal class EventsViewModelTest {
     fun init() {
         fakeRepository = FakeRepository()
         mockImageLoader = mockk(relaxed = true)
-    }
-
-    private fun setupViewModel() {
         viewModel = EventsViewModel(
             repository = fakeRepository,
             imageLoader = mockImageLoader,
@@ -43,36 +40,24 @@ internal class EventsViewModelTest {
     }
 
     @Test
-    fun `Should return empty list on first initialisation`() {
-        fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
-        fakeRepository.setLocalEventsForTest(emptyList())
-
-        setupViewModel()
-
-        val uiState = viewModel.uiState.value
-        uiState.isLoading shouldBe false
-        uiState.events shouldBe emptyList()
-        uiState.errorMessages.size shouldBe 0
-    }
-
-    @Test
-    fun `Should fetch cached events on initialisation`() {
+    fun `Should return refreshed events on fetchCacheAndRefresh`() {
         fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
         fakeRepository.setLocalEventsForTest(listOf(event3))
 
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
 
         val uiState = viewModel.uiState.value
         uiState.isLoading shouldBe false
-        uiState.events shouldContainExactly listOf(event3)
+        uiState.events shouldContainExactly listOf(event1, event2)
     }
 
     @Test
-    fun `Should return error on first initialisation when repository returned failure`() {
+    fun `Should return error without refresh on fetchCacheAndReload when fetching cache and repository returned failure`() {
         val exceptionMessage = "repository error"
         fakeRepository.setExceptionForTest(IOException(exceptionMessage))
+        fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
 
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
 
         val uiState = viewModel.uiState.value
         uiState.isLoading shouldBe false
@@ -85,7 +70,7 @@ internal class EventsViewModelTest {
     fun `Should fetch events successfully on refresh`() {
         fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
         fakeRepository.setLocalEventsForTest(listOf(event3))
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
 
         viewModel.refresh()
 
@@ -96,8 +81,8 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should return errors and keep previous cached events on failed refresh`() {
-        fakeRepository.setLocalEventsForTest(listOf(event3))
-        setupViewModel()
+        fakeRepository.setRemoteEventsForTest(listOf(event3))
+        viewModel.fetchCacheAndRefresh()
 
         val exceptionMessage = "repository error"
         fakeRepository.setExceptionForTest(IOException(exceptionMessage))
@@ -112,7 +97,7 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should update UI with error message on fetch failure`() {
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
         val errorMessage = "Test error"
         fakeRepository.setExceptionForTest(Exception(errorMessage))
 
@@ -125,7 +110,7 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should accumulate error messages in UIState upon multiple errors`() {
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
         val errorMessage1 = "Test error 1"
         val errorMessage2 = "Test error 2"
 
@@ -142,7 +127,7 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should remove error message when errorShown is called with valid ID`() {
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
         val errorMessage = "Test error"
         fakeRepository.setExceptionForTest(Exception(errorMessage))
 
@@ -156,7 +141,7 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should enable scroll to top when requested`() {
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
         val expectedRequestScrollToTop = true
         viewModel.requestScrollToTop(enabled = expectedRequestScrollToTop)
         val uiState = viewModel.uiState.value
@@ -165,7 +150,7 @@ internal class EventsViewModelTest {
 
     @Test
     fun `Should return the correct ImageLoader instance`() {
-        setupViewModel()
+        viewModel.fetchCacheAndRefresh()
         val expectedImageLoader = mockImageLoader
         val imageLoader = viewModel.getImageLoader()
         imageLoader shouldBeSameInstanceAs expectedImageLoader


### PR DESCRIPTION
Implemented new UIEevent onInitialLoad() so that the ViewModel will only start initialisation when the UI fires this event. Because of this, the cache fetching and network reload will be bundled together - which usually means the UI would expect state changes and eventually end up with a refreshed list.