### PR TITLE
(#18) media3 player library memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ now [logged as issues](https://github.com/ryanw-mobile/dazn-code-challenge/issue
 * Dependency Injection using Dagger Hilt
 * Material 3
 * Dynamic screen layout support using Windows Size Class
-* Media 3 video player
+* Jetpack Media 3 video player
 * Gradle Kotlin DSL and Version Catalog
 * Baseline Profile
 * Full unit test and UI (Journey) test suite
@@ -79,8 +79,7 @@ now [logged as issues](https://github.com/ryanw-mobile/dazn-code-challenge/issue
   screen solution
 * [Coil](https://coil-kt.github.io/coil/) - Image loading library for Android, leveraging Kotlin
   Coroutines
-* [compose-video](https://github.com/dsa28s/compose-video) - Media3 Video Player wrapper (buggy, to
-  be replaced/fixed)
+* [media3-exoplayer](https://developer.android.com/media/media3/exoplayer) - Video Player
 * [Dagger Hilt](https://dagger.dev/hilt/) - Dependency injection framework
 * [Timber](https://github.com/JakeWharton/timber) - Logging utility
 * [LeakCanary](https://github.com/square/leakcanary) - Memory leak detection tool

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,8 +198,8 @@ dependencies {
     implementation(libs.androidx.profileinstaller)
 
     // Video Player Library
-    implementation(libs.compose.video)
     implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.androidx.media3.dash)
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.ui)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,6 +248,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.mockk.android)
     testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.androidx.media3.test.utils)
 
     // For instrumented tests - with Kotlin
     androidTestImplementation(platform(libs.androidx.compose.bom))
@@ -260,6 +261,7 @@ dependencies {
     androidTestImplementation(libs.kotest.assertions.core)
     androidTestImplementation(libs.jetbrains.kotlinx.coroutines.test)
     androidTestImplementation(libs.hilt.android.testing)
+    androidTestImplementation(libs.androidx.media3.test.utils)
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {

--- a/app/src/androidTest/java/com/rwmobi/dazncodechallenge/di/TestDispatcherModule.kt
+++ b/app/src/androidTest/java/com/rwmobi/dazncodechallenge/di/TestDispatcherModule.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ */
+
+package com.rwmobi.dazncodechallenge.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [DispatcherModule::class],
+)
+object TestDispatcherModule {
+    @DispatcherModule.DefaultDispatcher
+    @Provides
+    fun providesDefaultDispatcher(): CoroutineDispatcher = UnconfinedTestDispatcher()
+
+    @DispatcherModule.IoDispatcher
+    @Provides
+    fun providesIoDispatcher(): CoroutineDispatcher = UnconfinedTestDispatcher()
+
+    @DispatcherModule.MainDispatcher
+    @Provides
+    fun providesMainDispatcher(): CoroutineDispatcher = UnconfinedTestDispatcher()
+}

--- a/app/src/androidTest/java/com/rwmobi/dazncodechallenge/di/TestExoPlayerModule.kt
+++ b/app/src/androidTest/java/com/rwmobi/dazncodechallenge/di/TestExoPlayerModule.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.di
+
+import android.content.Context
+import androidx.media3.common.Player
+import androidx.media3.test.utils.TestExoPlayerBuilder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.testing.TestInstallIn
+
+@Module
+@TestInstallIn(
+    components = [ViewModelComponent::class],
+    replaces = [ExoPlayerModule::class],
+)
+object TestExoPlayerModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideExoPlayer(
+        @ApplicationContext appContext: Context,
+    ): Player {
+        return TestExoPlayerBuilder(appContext).build()
+    }
+}

--- a/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/MainActivityTestRobot.kt
+++ b/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/MainActivityTestRobot.kt
@@ -15,13 +15,16 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 import com.rwmobi.dazncodechallenge.R
 import com.rwmobi.dazncodechallenge.ui.navigation.AppNavItem
@@ -36,6 +39,26 @@ internal class MainActivityTestRobot(
     }
 
     // Checks
+    fun checkTapEventsNavigationAndEventsTabIsSelected() {
+        try {
+            tapNavigationEvents()
+            assertEventsTabIsSelected()
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("MainActivityTestRobotError")
+            throw AssertionError("Expected events tab is not selected. ${e.message}", e)
+        }
+    }
+
+    fun checkTapScheduleNavigationAndScheduleTabIsSelected() {
+        try {
+            tapNavigationSchedule()
+            assertScheduleTabIsSelected()
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("MainActivityTestRobotError")
+            throw AssertionError("Expected schedule tab is not selected. ${e.message}", e)
+        }
+    }
+
     fun checkNavigationLayoutIsCorrect() {
         try {
             val windowWidthSizeClass = getWindowSizeClass().widthSizeClass
@@ -50,9 +73,38 @@ internal class MainActivityTestRobot(
         }
     }
 
+    fun checkExoPlayerIsDisplayedAndClosed() {
+        try {
+            assertExoPlayerIsDisplayed()
+            assertNavigationBarIsNotDisplayed()
+
+            Espresso.pressBack()
+            waitUntilPlayerDismissed()
+
+            assertExoPlayerIsNotDisplayed()
+            assertNavigationBarIsDisplayed()
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("MainActivityTestRobotError")
+            throw AssertionError("Expected ExoPlayer behaviour is not observed. ${e.message}", e)
+        }
+    }
+
+    fun checkSnackBarExceptionMessageIsDisplayedAndDismissed(exceptionMessage: String) {
+        try {
+            assertSnackbarIsDisplayed(message = exceptionMessage)
+            tapOK()
+            assertSnackbarIsNotDisplayed(message = exceptionMessage)
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("MainActivityTestRobotError")
+            throw AssertionError("Expected snackbar behaviour is not observed. ${e.message}", e)
+        }
+    }
+
     // Actions
     fun printSemanticTree() {
-        composeTestRule.onRoot().printToLog("SemanticTree")
+        with(composeTestRule) {
+            onRoot().printToLog("SemanticTree")
+        }
     }
 
     fun tapNavigationEvents() {
@@ -71,11 +123,19 @@ internal class MainActivityTestRobot(
         }
     }
 
-    fun waitUntilPlayerDismissed() {
+    private fun waitUntilPlayerDismissed() {
         with(composeTestRule) {
             waitUntil(timeoutMillis = 2_000) {
                 !onNodeWithContentDescription(label = activity.getString(R.string.content_description_video_player)).isDisplayed()
             }
+        }
+    }
+
+    private fun tapOK() {
+        with(composeTestRule) {
+            onNode(
+                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
+            ).performClick()
         }
     }
 
@@ -93,34 +153,6 @@ internal class MainActivityTestRobot(
     }
 
     // Assertions
-    fun assertNavigationBarIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_bar)).assertIsDisplayed()
-        }
-    }
-
-    fun assertNavigationBarIsNotDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_bar)).assertDoesNotExist()
-        }
-    }
-
-    fun assertNavigationRailIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_rail)).assertIsDisplayed()
-        }
-    }
-
-    fun assertNavigationItemsAreDisplayed() {
-        with(composeTestRule) {
-            for (navigationItem in AppNavItem.navBarItems) {
-                onNode(
-                    matcher = withRole(Role.Tab).and(hasContentDescription(value = activity.getString(navigationItem.titleResId))),
-                ).assertIsDisplayed()
-            }
-        }
-    }
-
     fun assertEventsTabIsSelected() {
         with(composeTestRule) {
             onNode(
@@ -133,7 +165,7 @@ internal class MainActivityTestRobot(
         }
     }
 
-    fun assertScheduleTabIsSelected() {
+    private fun assertScheduleTabIsSelected() {
         with(composeTestRule) {
             onNode(
                 matcher = withRole(Role.Tab).and(hasContentDescription(value = activity.getString(R.string.events))),
@@ -145,15 +177,61 @@ internal class MainActivityTestRobot(
         }
     }
 
-    fun assertExoPlayerIsDisplayed() {
+    private fun assertNavigationBarIsDisplayed() {
+        with(composeTestRule) {
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_bar)).assertIsDisplayed()
+        }
+    }
+
+    private fun assertNavigationBarIsNotDisplayed() {
+        with(composeTestRule) {
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_bar)).assertDoesNotExist()
+        }
+    }
+
+    private fun assertNavigationRailIsDisplayed() {
+        with(composeTestRule) {
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_navigation_rail)).assertIsDisplayed()
+        }
+    }
+
+    private fun assertNavigationItemsAreDisplayed() {
+        with(composeTestRule) {
+            for (navigationItem in AppNavItem.navBarItems) {
+                onNode(
+                    matcher = withRole(Role.Tab).and(hasContentDescription(value = activity.getString(navigationItem.titleResId))),
+                ).assertIsDisplayed()
+            }
+        }
+    }
+
+    private fun assertExoPlayerIsDisplayed() {
         with(composeTestRule) {
             onNodeWithContentDescription(label = activity.getString(R.string.content_description_video_player)).assertIsDisplayed()
         }
     }
 
-    fun assertExoPlayerIsNotDisplayed() {
+    private fun assertExoPlayerIsNotDisplayed() {
         with(composeTestRule) {
             onNodeWithContentDescription(label = activity.getString(R.string.content_description_video_player)).assertDoesNotExist()
+        }
+    }
+
+    private fun assertSnackbarIsDisplayed(message: String) {
+        with(composeTestRule) {
+            onNodeWithText(text = message).assertIsDisplayed()
+            onNode(
+                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
+            ).assertIsDisplayed()
+        }
+    }
+
+    private fun assertSnackbarIsNotDisplayed(message: String) {
+        with(composeTestRule) {
+            onNodeWithText(text = message).assertDoesNotExist()
+            onNode(
+                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
+            ).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreenTestRobot.kt
+++ b/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreenTestRobot.kt
@@ -7,9 +7,7 @@
 
 package com.rwmobi.dazncodechallenge.ui.destinations.events
 
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
@@ -19,14 +17,45 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.test.swipeDown
 import com.rwmobi.dazncodechallenge.R
+import com.rwmobi.dazncodechallenge.domain.model.Event
 import com.rwmobi.dazncodechallenge.ui.test.DaznCodeChallengeTestRule
-import com.rwmobi.dazncodechallenge.ui.test.withRole
+import com.rwmobi.dazncodechallenge.ui.test.EventsListSampleData
 
 internal class EventsScreenTestRobot(
     private val composeTestRule: DaznCodeChallengeTestRule,
 ) {
+    // Checks
+    fun checkAllListItemsAreDisplayed(events: List<Event>) {
+        try {
+            assertNoDataScreenIsNotDisplayed()
+            assertEventListIsDisplayed()
+            for (index in events.indices) {
+                scrollToListItem(index)
+                assertEventItemIsDisplayed(
+                    title = EventsListSampleData.listOfSixteen[index].title,
+                )
+            }
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("EventsScreenTestRobotError")
+            throw AssertionError("Expected event items are not all displayed. ${e.message}", e)
+        }
+    }
+
+    fun checkNoDataScreenIsDisplayed() {
+        try {
+            assertNoDataScreenIsDisplayed()
+            assertEventListIsNotDisplayed()
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("EventsScreenTestRobotError")
+            throw AssertionError("Expected no data screen is not displayed. ${e.message}", e)
+        }
+    }
+
+    // Actions
     fun printSemanticTree() {
-        composeTestRule.onRoot().printToLog("SemanticTree")
+        with(composeTestRule) {
+            onRoot().printToLog("SemanticTree")
+        }
     }
 
     fun performPullToRefresh() {
@@ -42,71 +71,46 @@ internal class EventsScreenTestRobot(
         }
     }
 
-    fun tapOK() {
-        with(composeTestRule) {
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).performClick()
-        }
-    }
-
-    fun tapListItem(index: Int) {
+    fun scrollAndTapListItem(index: Int) {
         with(composeTestRule) {
             onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).performScrollToIndex(index = index).performClick()
         }
     }
 
-    fun scrollToListItem(index: Int) {
+    private fun scrollToListItem(index: Int) {
         with(composeTestRule) {
             onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).performScrollToIndex(index = index)
         }
     }
 
-    fun assertEventListIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).assertIsDisplayed()
-        }
-    }
-
-    fun assertEventListIsNotDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).assertDoesNotExist()
-        }
-    }
-
-    fun assertNoDataScreenIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithText(text = activity.getString(R.string.no_data)).assertIsDisplayed()
-        }
-    }
-
-    fun assertNoDataScreenIsNotDisplayed() {
-        with(composeTestRule) {
-            onNodeWithText(text = activity.getString(R.string.no_data)).assertDoesNotExist()
-        }
-    }
-
+    // Assertions
     fun assertEventItemIsDisplayed(title: String) {
         with(composeTestRule) {
             onNodeWithText(text = title).assertIsDisplayed()
         }
     }
 
-    fun assertSnackbarIsDisplayed(message: String) {
+    private fun assertEventListIsDisplayed() {
         with(composeTestRule) {
-            onNodeWithText(text = message).assertIsDisplayed()
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).assertIsDisplayed()
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).assertIsDisplayed()
         }
     }
 
-    fun assertSnackbarIsNotDisplayed(message: String) {
+    private fun assertEventListIsNotDisplayed() {
         with(composeTestRule) {
-            onNodeWithText(text = message).assertDoesNotExist()
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).assertDoesNotExist()
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_events_list)).assertDoesNotExist()
+        }
+    }
+
+    private fun assertNoDataScreenIsDisplayed() {
+        with(composeTestRule) {
+            onNodeWithText(text = activity.getString(R.string.no_data)).assertIsDisplayed()
+        }
+    }
+
+    private fun assertNoDataScreenIsNotDisplayed() {
+        with(composeTestRule) {
+            onNodeWithText(text = activity.getString(R.string.no_data)).assertDoesNotExist()
         }
     }
 }

--- a/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreenTestRobot.kt
+++ b/app/src/androidTest/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreenTestRobot.kt
@@ -7,85 +7,88 @@
 
 package com.rwmobi.dazncodechallenge.ui.destinations.schedule
 
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.printToLog
 import com.rwmobi.dazncodechallenge.R
+import com.rwmobi.dazncodechallenge.domain.model.Schedule
 import com.rwmobi.dazncodechallenge.ui.test.DaznCodeChallengeTestRule
-import com.rwmobi.dazncodechallenge.ui.test.withRole
+import com.rwmobi.dazncodechallenge.ui.test.EventsListSampleData
 
 internal class ScheduleScreenTestRobot(
     private val composeTestRule: DaznCodeChallengeTestRule,
 ) {
-    fun printSemanticTree() {
-        composeTestRule.onRoot().printToLog("SemanticTree")
+    // Checks
+    fun checkNoDataScreenIsDisplayed() {
+        try {
+            assertNoDataScreenIsDisplayed()
+            assertScheduleListIsNotDisplayed()
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("ScheduleScreenTestRobotError")
+            throw AssertionError("Expected no data screen is not displayed. ${e.message}", e)
+        }
     }
 
-    fun scrollToListItem(index: Int) {
+    fun checkAllListItemsAreDisplayed(schedule: List<Schedule>) {
+        try {
+            assertNoDataScreenIsNotDisplayed()
+            assertScheduleListIsDisplayed()
+            for (index in schedule.indices) {
+                scrollToListItem(index)
+                assertScheduleItemIsDisplayed(
+                    title = EventsListSampleData.listOfSixteen[index].title,
+                )
+            }
+        } catch (e: AssertionError) {
+            composeTestRule.onRoot().printToLog("ScheduleScreenTestRobotError")
+            throw AssertionError("Expected schedule items are not all displayed. ${e.message}", e)
+        }
+    }
+
+    // Actions
+    fun printSemanticTree() {
+        with(composeTestRule) {
+            onRoot().printToLog("SemanticTree")
+        }
+    }
+
+    private fun scrollToListItem(index: Int) {
         with(composeTestRule) {
             onNodeWithContentDescription(label = activity.getString(R.string.content_description_schedule_list)).performScrollToIndex(index = index)
         }
     }
 
-    fun tapOK() {
-        with(composeTestRule) {
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).performClick()
-        }
-    }
-
-    fun assertScheduleListIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_schedule_list)).assertIsDisplayed()
-        }
-    }
-
-    fun assertScheduleListIsNotDisplayed() {
-        with(composeTestRule) {
-            onNodeWithContentDescription(label = activity.getString(R.string.content_description_schedule_list)).assertDoesNotExist()
-        }
-    }
-
-    fun assertNoDataScreenIsDisplayed() {
-        with(composeTestRule) {
-            onNodeWithText(text = activity.getString(R.string.no_data)).assertIsDisplayed()
-        }
-    }
-
-    fun assertNoDataScreenIsNotDisplayed() {
-        with(composeTestRule) {
-            onNodeWithText(text = activity.getString(R.string.no_data)).assertDoesNotExist()
-        }
-    }
-
+    // Assertions
     fun assertScheduleItemIsDisplayed(title: String) {
         with(composeTestRule) {
             onNodeWithText(text = title).assertIsDisplayed()
         }
     }
 
-    fun assertSnackbarIsDisplayed(message: String) {
+    private fun assertScheduleListIsDisplayed() {
         with(composeTestRule) {
-            onNodeWithText(text = message).assertIsDisplayed()
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).assertIsDisplayed()
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_schedule_list)).assertIsDisplayed()
         }
     }
 
-    fun assertSnackbarIsNotDisplayed(message: String) {
+    private fun assertScheduleListIsNotDisplayed() {
         with(composeTestRule) {
-            onNodeWithText(text = message).assertDoesNotExist()
-            onNode(
-                matcher = withRole(Role.Button).and(hasText(text = activity.getString(R.string.ok))),
-            ).assertDoesNotExist()
+            onNodeWithContentDescription(label = activity.getString(R.string.content_description_schedule_list)).assertDoesNotExist()
+        }
+    }
+
+    private fun assertNoDataScreenIsDisplayed() {
+        with(composeTestRule) {
+            onNodeWithText(text = activity.getString(R.string.no_data)).assertIsDisplayed()
+        }
+    }
+
+    private fun assertNoDataScreenIsNotDisplayed() {
+        with(composeTestRule) {
+            onNodeWithText(text = activity.getString(R.string.no_data)).assertDoesNotExist()
         }
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/di/ExoPlayerModule.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/di/ExoPlayerModule.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.di
+
+import android.content.Context
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object ExoPlayerModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideExoPlayer(
+        @ApplicationContext appContext: Context,
+    ): Player {
+        return ExoPlayer
+            .Builder(appContext)
+            .build()
+    }
+}

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -96,6 +96,8 @@ fun ExoPlayerScreen(
     }
 
     LaunchedEffect(true) {
-        uiEvent.onPlayVideo()
+        if (!uiState.hasVideoLoaded) {
+            uiEvent.onPlayVideo()
+        }
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -62,7 +62,7 @@ fun ExoPlayerScreen(
 
         AndroidView(
             factory = { context ->
-                PlayerView(context).also {
+                PlayerView(context.applicationContext).also {
                     it.player = player
                 }
             },

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.Player
 import androidx.media3.ui.PlayerView
-import timber.log.Timber
 
 @Composable
 fun ExoPlayerScreen(
@@ -75,16 +74,6 @@ fun ExoPlayerScreen(
 
                     Lifecycle.Event.ON_RESUME -> {
                         it.onResume()
-                    }
-
-                    Lifecycle.Event.ON_STOP -> {
-                        Timber.d("OnStop: ${it.player?.currentPosition}")
-                        it.player = null
-                    }
-
-                    Lifecycle.Event.ON_DESTROY -> {
-                        Timber.d("OnDestroy: ${it.player?.currentPosition}")
-                        it.player = null
                     }
 
                     else -> Unit

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -17,12 +17,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.Player
 import androidx.media3.ui.PlayerView
+import com.rwmobi.dazncodechallenge.R
 
 @Composable
 fun ExoPlayerScreen(
@@ -59,6 +63,7 @@ fun ExoPlayerScreen(
             }
         }
 
+        val localContext = LocalContext.current
         AndroidView(
             factory = { context ->
                 PlayerView(context.applicationContext).also {
@@ -80,7 +85,8 @@ fun ExoPlayerScreen(
                 }
             },
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = localContext.getString(R.string.content_description_video_player) },
         )
     }
 

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -7,64 +7,95 @@
 
 package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
 
-import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import com.rwmobi.dazncodechallenge.R
-import io.sanghun.compose.video.RepeatMode
-import io.sanghun.compose.video.VideoPlayer
-import io.sanghun.compose.video.controller.VideoPlayerControllerConfig
-import io.sanghun.compose.video.uri.VideoPlayerMediaItem
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerView
 import timber.log.Timber
 
 @Composable
 fun ExoPlayerScreen(
     modifier: Modifier = Modifier,
-    videoUrl: Uri,
+    player: Player,
+    uiState: ExoPlayerUIState,
+    uiEvent: ExoPlayerUIEvent,
 ) {
-    val context = LocalContext.current
-
     Box(
         modifier = modifier,
     ) {
-        VideoPlayer(
-            modifier = Modifier
-                .fillMaxSize()
-                .align(Alignment.Center)
-                .semantics { contentDescription = context.getString(R.string.content_description_video_player) },
-            mediaItems = listOf(
-                VideoPlayerMediaItem.NetworkMediaItem(url = videoUrl.toString()),
-            ),
-            handleLifecycle = true,
-            autoPlay = true,
-            usePlayerController = true,
-            enablePip = false,
-            handleAudioFocus = true,
-            controllerConfig = VideoPlayerControllerConfig(
-                showSpeedAndPitchOverlay = false,
-                showSubtitleButton = false,
-                showCurrentTimeAndTotalTime = true,
-                showBufferingProgress = true,
-                showForwardIncrementButton = true,
-                showBackwardIncrementButton = true,
-                showBackTrackButton = false,
-                showNextTrackButton = false,
-                showFullScreenButton = false, // We made it fullscreen already. Simply rotates the App and we support natively
-                showRepeatModeButton = true,
-                controllerShowTimeMilliSeconds = 5_000,
-                controllerAutoShow = true,
-            ),
-            volume = 0.5f, // volume 0.0f to 1.0f
-            repeatMode = RepeatMode.NONE, // or RepeatMode.ALL, RepeatMode.ONE
-            onCurrentTimeChanged = { // long type, current player time (millisec)
-                Timber.tag("CurrentTime").e(it.toString())
+        if (uiState.errorMessages.isNotEmpty()) {
+            val errorMessage = remember(uiState) { uiState.errorMessages[0] }
+            val errorMessageText = errorMessage.message
+
+            LaunchedEffect(errorMessage.id) {
+                uiEvent.onShowSnackbar(errorMessageText)
+                uiEvent.onErrorShown(errorMessage.id)
+            }
+        }
+
+        var lifecycle by remember {
+            mutableStateOf(Lifecycle.Event.ON_CREATE)
+        }
+        val lifecycleOwner = LocalLifecycleOwner.current
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                lifecycle = event
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+
+            onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
+        }
+
+        AndroidView(
+            factory = { context ->
+                PlayerView(context).also {
+                    it.player = player
+                }
             },
+            update = {
+                when (lifecycle) {
+                    Lifecycle.Event.ON_PAUSE -> {
+                        it.onPause()
+                        it.player?.pause()
+                    }
+
+                    Lifecycle.Event.ON_RESUME -> {
+                        it.onResume()
+                    }
+
+                    Lifecycle.Event.ON_STOP -> {
+                        Timber.d("OnStop: ${it.player?.currentPosition}")
+                        it.player = null
+                    }
+
+                    Lifecycle.Event.ON_DESTROY -> {
+                        Timber.d("OnDestroy: ${it.player?.currentPosition}")
+                        it.player = null
+                    }
+
+                    else -> Unit
+                }
+            },
+            modifier = Modifier
+                .fillMaxSize(),
         )
+    }
+
+    LaunchedEffect(true) {
+        uiEvent.onPlayVideo()
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIEvent.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
+
+data class ExoPlayerUIEvent(
+    val onPlayVideo: () -> Unit,
+    val onErrorShown: (errorId: Long) -> Unit,
+    val onShowSnackbar: suspend (message: String) -> Unit,
+)

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIState.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIState.kt
@@ -10,5 +10,6 @@ package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
 import com.rwmobi.dazncodechallenge.ui.model.ErrorMessage
 
 data class ExoPlayerUIState(
+    val hasVideoLoaded: Boolean = false,
     val errorMessages: List<ErrorMessage> = emptyList(),
 )

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIState.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerUIState.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
+
+import com.rwmobi.dazncodechallenge.ui.model.ErrorMessage
+
+data class ExoPlayerUIState(
+    val errorMessages: List<ErrorMessage> = emptyList(),
+)

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
@@ -23,11 +23,13 @@ import androidx.navigation.navArgument
 import com.rwmobi.dazncodechallenge.ui.destinations.events.EventsScreen
 import com.rwmobi.dazncodechallenge.ui.destinations.events.EventsUIEvent
 import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerScreen
+import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerUIEvent
 import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleScreen
 import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleUIEvent
 import com.rwmobi.dazncodechallenge.ui.theme.dazn_background
 import com.rwmobi.dazncodechallenge.ui.theme.dazn_surface
 import com.rwmobi.dazncodechallenge.ui.viewmodel.EventsViewModel
+import com.rwmobi.dazncodechallenge.ui.viewmodel.ExoPlayerViewModel
 import com.rwmobi.dazncodechallenge.ui.viewmodel.ScheduleViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -107,11 +109,20 @@ fun AppNavHost(
             val videoUrlStr = backStackEntry.arguments?.getString("videoUrl") ?: ""
             val videoUrl = Uri.parse(videoUrlStr)
 
+            val viewModel: ExoPlayerViewModel = hiltViewModel()
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
             ExoPlayerScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(color = dazn_background),
-                videoUrl = videoUrl,
+                player = viewModel.getPlayer(),
+                uiState = uiState,
+                uiEvent = ExoPlayerUIEvent(
+                    onPlayVideo = { viewModel.playVideo(videoUrl = videoUrl.toString()) },
+                    onErrorShown = { viewModel.errorShown(it) },
+                    onShowSnackbar = onShowSnackbar,
+                ),
             )
         }
     }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
@@ -25,12 +25,10 @@ import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
-class EventsViewModel
-@Inject
-constructor(
+class EventsViewModel @Inject constructor(
     private val repository: Repository,
     private val imageLoader: ImageLoader,
-    @DispatcherModule.MainDispatcher private val dispatcher: CoroutineDispatcher,
+    @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<EventsUIState> = MutableStateFlow(EventsUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -28,6 +28,8 @@ class ExoPlayerViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<ExoPlayerUIState> = MutableStateFlow(ExoPlayerUIState())
     val uiState = _uiState.asStateFlow()
 
+    private var videoUrl: String? = null
+
     init {
         player.prepare()
         player.addListener(
@@ -72,7 +74,7 @@ class ExoPlayerViewModel @Inject constructor(
 
     fun playVideo(videoUrl: String) {
         // Intended to resume playing position when device is rotated
-        if (!_uiState.value.hasVideoLoaded) {
+        if (!_uiState.value.hasVideoLoaded || videoUrl != this.videoUrl) {
             player.apply {
                 setMediaItem(
                     MediaItem.fromUri(videoUrl),

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -29,6 +29,8 @@ class ExoPlayerViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<ExoPlayerUIState> = MutableStateFlow(ExoPlayerUIState())
     val uiState = _uiState.asStateFlow()
 
+    private var hasPlayed = false
+
     init {
         Timber.d("player initialising")
         player.prepare()
@@ -74,9 +76,19 @@ class ExoPlayerViewModel @Inject constructor(
     fun getPlayer() = player
 
     fun playVideo(videoUrl: String) {
-        player.setMediaItem(
-            MediaItem.fromUri(videoUrl),
-        )
+        // Intended to resume playing position when device is rotated
+        if (!_uiState.value.hasVideoLoaded) {
+            player.apply {
+                setMediaItem(
+                    MediaItem.fromUri(videoUrl),
+                )
+                play()
+            }
+
+            _uiState.update { currentUiState ->
+                currentUiState.copy(hasVideoLoaded = true)
+            }
+        }
     }
 
     private fun updateUIForError(message: String) {

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.datasource.HttpDataSource
+import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerUIState
+import com.rwmobi.dazncodechallenge.ui.model.ErrorMessage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class ExoPlayerViewModel @Inject constructor(
+    private val player: Player,
+) : ViewModel() {
+    private val _uiState: MutableStateFlow<ExoPlayerUIState> = MutableStateFlow(ExoPlayerUIState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        Timber.d("player initialising")
+        player.prepare()
+        player.addListener(
+            object : Player.Listener {
+                override fun onPlayerError(error: PlaybackException) {
+                    val cause = error.cause
+                    if (cause is HttpDataSource.HttpDataSourceException) {
+                        // An HTTP error occurred.
+                        val httpError = cause
+                        // It's possible to find out more about the error both by casting and by querying
+                        // the cause.
+                        if (httpError is HttpDataSource.InvalidResponseCodeException) {
+                            // Cast to InvalidResponseCodeException and retrieve the response code, message
+                            // and headers.
+                            updateUIForError(message = "HTTP Error ${httpError.responseCode}")
+                        } else {
+                            // Try calling httpError.getCause() to retrieve the underlying cause, although
+                            // note that it may be null.
+                            httpError.cause?.message?.let { message ->
+                                updateUIForError(message = message)
+                            }
+                        }
+                    }
+                }
+            },
+        )
+    }
+
+    fun errorShown(errorId: Long) {
+        _uiState.update { currentUiState ->
+            val errorMessages = currentUiState.errorMessages.filterNot { it.id == errorId }
+            currentUiState.copy(errorMessages = errorMessages)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Timber.d("player releasing")
+        player.release()
+    }
+
+    fun getPlayer() = player
+
+    fun playVideo(videoUrl: String) {
+        player.setMediaItem(
+            MediaItem.fromUri(videoUrl),
+        )
+    }
+
+    private fun updateUIForError(message: String) {
+        _uiState.update {
+            addErrorMessage(
+                currentUiState = it,
+                message = message,
+            )
+        }
+    }
+
+    private fun addErrorMessage(currentUiState: ExoPlayerUIState, message: String): ExoPlayerUIState {
+        val newErrorMessage = ErrorMessage(
+            id = UUID.randomUUID().mostSignificantBits,
+            message = message,
+        )
+        return currentUiState.copy(
+            errorMessages = currentUiState.errorMessages + newErrorMessage,
+        )
+    }
+}

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -29,10 +28,7 @@ class ExoPlayerViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<ExoPlayerUIState> = MutableStateFlow(ExoPlayerUIState())
     val uiState = _uiState.asStateFlow()
 
-    private var hasPlayed = false
-
     init {
-        Timber.d("player initialising")
         player.prepare()
         player.addListener(
             object : Player.Listener {
@@ -69,7 +65,6 @@ class ExoPlayerViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        Timber.d("player releasing")
         player.release()
     }
 

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -52,6 +52,10 @@ class ExoPlayerViewModel @Inject constructor(
                                 updateUIForError(message = message)
                             }
                         }
+                    } else {
+                        cause?.message?.let { message ->
+                            updateUIForError(message = message)
+                        }
                     }
                 }
             },

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 class ScheduleViewModel @Inject constructor(
     private val repository: Repository,
     private val imageLoader: ImageLoader,
-    @DispatcherModule.MainDispatcher private val dispatcher: CoroutineDispatcher,
+    @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<ScheduleUIState> = MutableStateFlow(ScheduleUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModelTest.kt
@@ -1,0 +1,124 @@
+package com.rwmobi.dazncodechallenge.ui.viewmodel
+
+import androidx.media3.common.Player
+import com.rwmobi.dazncodechallenge.test.PlaybackExceptionSampleData
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class ExoPlayerViewModelTest {
+    private lateinit var mockPlayer: Player
+    private lateinit var listenerSlot: CapturingSlot<Player.Listener>
+
+    // Subject under test
+    private lateinit var viewModel: ExoPlayerViewModel
+
+    @Before
+    fun init() {
+        mockPlayer = mockk(relaxed = true)
+        listenerSlot = slot<Player.Listener>()
+        every { mockPlayer.addListener(capture(listenerSlot)) } just runs
+        viewModel = ExoPlayerViewModel(player = mockPlayer)
+    }
+
+    @Test
+    fun uiState_initialState_ShouldBeCorrect() {
+        val uiState = viewModel.uiState.value
+        assert(uiState.errorMessages.isEmpty())
+        assert(!uiState.hasVideoLoaded)
+    }
+
+    @Test
+    fun playVideo_withNewVideoUrl_ShouldPlayVideoAndSetLoaded() = runTest {
+        val videoUrl = "http://fakevideo.com/video.mp4"
+        viewModel.playVideo(videoUrl)
+        val uiState = viewModel.uiState.value
+        uiState.hasVideoLoaded shouldBe true
+    }
+
+    @Test
+    fun onPlayerError_withHTTPError_ShouldUpdateUIState() = runTest {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.invalidResponseCodeException)
+        }
+
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        val errorMessages = viewModel.uiState.value.errorMessages
+        errorMessages.size shouldBe 1
+        errorMessages[0].message shouldBe "HTTP Error ${PlaybackExceptionSampleData.invalidResponseCodeExceptionErrorCode}"
+    }
+
+    @Test
+    fun onPlayerError_withHttpDataSourceException_ShouldUpdateUIState() = runTest {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.httpDataSourceException)
+        }
+
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        val errorMessages = viewModel.uiState.value.errorMessages
+        errorMessages.size shouldBe 1
+        errorMessages[0].message shouldBe PlaybackExceptionSampleData.httpDataSourceExceptionMessage
+    }
+
+    @Test
+    fun onPlayerError_withOtherExceptions_ShouldUpdateUIState() = runTest {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+        }
+
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        val errorMessages = viewModel.uiState.value.errorMessages
+        errorMessages.size shouldBe 1
+        errorMessages[0].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
+    }
+
+    @Test
+    fun getPlayer_ShouldReturnCorrectInstance() {
+        val expectedPlayer = mockPlayer
+        val player = viewModel.getPlayer()
+        player shouldBeSameInstanceAs expectedPlayer
+    }
+
+    @Test
+    fun refresh_ShouldAccumulateErrorMessages_OnMultipleFailures() {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+        }
+
+        repeat(times = 2) {
+            viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+        }
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 2
+        uiState.errorMessages[0].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
+        uiState.errorMessages[1].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
+    }
+
+    @Test
+    fun errorShown_ShouldClearErrorMessage_WhenCalledWithValidId() {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+        }
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        val errorId = viewModel.uiState.value.errorMessages.first().id
+        viewModel.errorShown(errorId)
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages shouldBe emptyList()
+    }
+}

--- a/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
+++ b/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.test
+
+import android.net.Uri
+import androidx.media3.common.PlaybackException
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import java.io.IOException
+
+object PlaybackExceptionSampleData {
+    val invalidResponseCodeExceptionErrorCode = 403
+    val invalidResponseCodeException = PlaybackException(
+        "Connection Failed",
+        HttpDataSource.InvalidResponseCodeException(
+            invalidResponseCodeExceptionErrorCode,
+            "Response message",
+            IOException("Cause message"),
+            emptyMap(),
+            DataSpec(Uri.parse("https://someview.com/video.mp4")),
+            ByteArray(0),
+        ),
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+    )
+
+    val httpDataSourceExceptionMessage = "Some IO Exception"
+    val httpDataSourceException = PlaybackException(
+        "Connection Failed",
+        HttpDataSource.HttpDataSourceException(
+            "Error message",
+            IOException(httpDataSourceExceptionMessage),
+            DataSpec(Uri.parse("https://someview.com/video.mp4")),
+            PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
+            HttpDataSource.HttpDataSourceException.TYPE_OPEN,
+        ),
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+    )
+
+    val genericExceptionMessage = "Some generic exception"
+    val genericException = PlaybackException(
+        "Connection Failed",
+        Exception(genericExceptionMessage),
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,14 +48,13 @@ uiautomator = "2.3.0"
 baselineprofile = "1.3.0-alpha03"
 profileinstaller = "1.4.0-alpha01"
 media3Exoplayer = "1.3.1"
-composeVideo = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
+androidx-media3-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3Exoplayer" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3Exoplayer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
-compose-video = { module = "io.sanghun:compose-video", version.ref = "composeVideo" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-media3-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3Exoplayer" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3Exoplayer" }
+androidx-media3-test-utils = { module = "androidx.media3:media3-test-utils", version.ref = "media3Exoplayer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Replaced the media3 library with our own native implementation, so that we can have direct control on what context to supply to the player - and the memory leak was fixed.

Because we created a new ViewModel, added unit test for it.

Also refactored some UI tests.