### PR TITLE
ViewModel: change to queue only unique error messages

### DIFF
--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModel.kt
@@ -100,23 +100,19 @@ class EventsViewModel @Inject constructor(
     }
 
     private fun updateUIForError(message: String) {
-        _uiState.update {
-            addErrorMessage(
-                currentUiState = it,
-                message = message,
+        _uiState.update { currentUiState ->
+            val newErrorMessages = if (_uiState.value.errorMessages.any { it.message == message }) {
+                currentUiState.errorMessages
+            } else {
+                currentUiState.errorMessages + ErrorMessage(
+                    id = UUID.randomUUID().mostSignificantBits,
+                    message = message,
+                )
+            }
+            currentUiState.copy(
+                isLoading = false,
+                errorMessages = newErrorMessages,
             )
         }
-    }
-
-    private fun addErrorMessage(currentUiState: EventsUIState, message: String): EventsUIState {
-        val newErrorMessage = ErrorMessage(
-            id = UUID.randomUUID().mostSignificantBits,
-            message = message,
-        )
-        return currentUiState.copy(
-            // So that each time we show a message we expect loading should have stopped
-            isLoading = false,
-            errorMessages = currentUiState.errorMessages + newErrorMessage,
-        )
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModel.kt
@@ -128,21 +128,18 @@ class ExoPlayerViewModel @Inject constructor(
     }
 
     private fun updateUIForError(message: String) {
-        _uiState.update {
-            addErrorMessage(
-                currentUiState = it,
-                message = message,
+        _uiState.update { currentUiState ->
+            val newErrorMessages = if (_uiState.value.errorMessages.any { it.message == message }) {
+                currentUiState.errorMessages
+            } else {
+                currentUiState.errorMessages + ErrorMessage(
+                    id = UUID.randomUUID().mostSignificantBits,
+                    message = message,
+                )
+            }
+            currentUiState.copy(
+                errorMessages = newErrorMessages,
             )
         }
-    }
-
-    private fun addErrorMessage(currentUiState: ExoPlayerUIState, message: String): ExoPlayerUIState {
-        val newErrorMessage = ErrorMessage(
-            id = UUID.randomUUID().mostSignificantBits,
-            message = message,
-        )
-        return currentUiState.copy(
-            errorMessages = currentUiState.errorMessages + newErrorMessage,
-        )
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModel.kt
@@ -101,23 +101,19 @@ class ScheduleViewModel @Inject constructor(
     }
 
     private fun updateUIForError(message: String) {
-        _uiState.update {
-            addErrorMessage(
-                currentUiState = it,
-                message = message,
+        _uiState.update { currentUiState ->
+            val newErrorMessages = if (_uiState.value.errorMessages.any { it.message == message }) {
+                currentUiState.errorMessages
+            } else {
+                currentUiState.errorMessages + ErrorMessage(
+                    id = UUID.randomUUID().mostSignificantBits,
+                    message = message,
+                )
+            }
+            currentUiState.copy(
+                isLoading = false,
+                errorMessages = newErrorMessages,
             )
         }
-    }
-
-    private fun addErrorMessage(currentUiState: ScheduleUIState, message: String): ScheduleUIState {
-        val newErrorMessage = ErrorMessage(
-            id = UUID.randomUUID().mostSignificantBits,
-            message = message,
-        )
-        return currentUiState.copy(
-            // So that each time we show a message we expect loading should have stopped
-            isLoading = false,
-            errorMessages = currentUiState.errorMessages + newErrorMessage,
-        )
     }
 }

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/EventsViewModelTest.kt
@@ -128,6 +128,21 @@ internal class EventsViewModelTest {
     }
 
     @Test
+    fun refresh_ShouldNotAccumulateDuplicatedErrorMessages_OnMultipleFailures() {
+        viewModel.fetchCacheAndRefresh()
+        val errorMessage1 = "Test error 1"
+
+        repeat(times = 2) {
+            fakeRepository.setExceptionForTest(Exception(errorMessage1))
+            viewModel.refresh()
+        }
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 1
+        uiState.errorMessages[0].message shouldBe errorMessage1
+    }
+
+    @Test
     fun errorShown_ShouldClearErrorMessage_WhenCalledWithValidId() {
         viewModel.fetchCacheAndRefresh()
         val errorMessage = "Test error"

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ExoPlayerViewModelTest.kt
@@ -146,15 +146,32 @@ internal class ExoPlayerViewModelTest {
         every { mockPlayer.play() } answers {
             listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
         }
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.ioException)
+        }
+        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 2
+        uiState.errorMessages[0].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
+        uiState.errorMessages[1].message shouldBe PlaybackExceptionSampleData.ioExceptionMessage
+    }
+
+    @Test
+    fun refresh_ShouldNotAccumulateDuplicatedErrorMessages_OnMultipleFailures() {
+        every { mockPlayer.play() } answers {
+            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+        }
 
         repeat(times = 2) {
             viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
         }
 
         val uiState = viewModel.uiState.value
-        uiState.errorMessages.size shouldBe 2
+        uiState.errorMessages.size shouldBe 1
         uiState.errorMessages[0].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
-        uiState.errorMessages[1].message shouldBe PlaybackExceptionSampleData.genericExceptionMessage
     }
 
     @Test

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/viewmodel/ScheduleViewModelTest.kt
@@ -128,6 +128,21 @@ internal class ScheduleViewModelTest {
     }
 
     @Test
+    fun refresh_ShouldNotAccumulateDuplicatedErrorMessages_OnMultipleFailures() {
+        viewModel.fetchCacheAndRefresh()
+        val errorMessage1 = "Test error 1"
+
+        repeat(times = 2) {
+            fakeRepository.setExceptionForTest(Exception(errorMessage1))
+            viewModel.refresh()
+        }
+
+        val uiState = viewModel.uiState.value
+        uiState.errorMessages.size shouldBe 1
+        uiState.errorMessages[0].message shouldBe errorMessage1
+    }
+
+    @Test
     fun errorShown_ShouldClearErrorMessage_WhenCalledWithValidId() {
         viewModel.fetchCacheAndRefresh()
         val errorMessage = "Test error"

--- a/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
+++ b/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
@@ -47,4 +47,11 @@ object PlaybackExceptionSampleData {
         Exception(genericExceptionMessage),
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
     )
+
+    val ioExceptionMessage = "Some IO exception"
+    val ioException = PlaybackException(
+        "Connection Failed",
+        Exception(ioExceptionMessage),
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+    )
 }


### PR DESCRIPTION
This helps improve user experience as no point showing the same error over and over again.