### PR TITLE
(#77) Run UI test when updating dependencies

### DIFF
--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
       - name: Decode Keystore
         id: decode_keystore
         uses: timheuer/base64-to-file@v1.2

--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -31,7 +31,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Gradle Check
-        run: ./gradlew check assembleDebug --no-daemon
+        run: ./gradlew check assembleDebug :app:pixel6Api34DebugAndroidTest --no-daemon
         env:
           CI: 'true'
           KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ lint/tmp/
 # lint/reports/
 .idea
 # app/src/release/generated/baselineProfiles
+
+.kotlin/metadata
+.kotlin/sessions

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@
  *
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 import java.io.FileInputStream
 import java.io.InputStreamReader
@@ -163,6 +164,16 @@ android {
         unitTests {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
+        }
+
+        managedDevices {
+            devices {
+                create<ManagedVirtualDevice>("pixel6Api34") {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    systemImageSource = "google"
+                }
+            }
         }
     }
 

--- a/renovate.json
+++ b/renovate.json
@@ -30,18 +30,6 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
-    },
-    {
-      "matchPackageNames": [
-        "androidx.lifecycle:lifecycle-viewmodel-ktx",
-        "androidx.lifecycle:lifecycle-runtime-ktx",
-        "androidx.lifecycle:lifecycle-runtime-compose"
-      ],
-      "groupName": "androidx-lifecycle",
-      "automerge": false,
-      "labels": [
-        "requires-approval"
-      ]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
To fully automate renovate dependency update, we also run UI test to ensure no runtime issues. 
Therefore as a side effect, we have lifted the manual approval of Jetpack Lifecycle update - as UI test will fail 